### PR TITLE
bump ent-utils to ^4.10.0 and ent-drivers to ^2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "bluebird": "^2.9.8",
-    "ent-drivers": "^1.1.0",
-    "ent-utils": "^1.17.0",
+    "ent-drivers": "^2.1.0",
+    "ent-utils": "^4.10.0",
     "joi": "^9.0.4",
     "lodash": "^3.10.1",
     "node-uuid": "^1.4.7"


### PR DESCRIPTION
bumped ent-utils & ent-drivers versions. no additional work needed

 +patch